### PR TITLE
feat(core): add BaseEntity and AuditableEntity with auto-timestamps

### DIFF
--- a/src/LetopiaPlatform.Core/Common/AuditableEntity.cs
+++ b/src/LetopiaPlatform.Core/Common/AuditableEntity.cs
@@ -1,0 +1,14 @@
+namespace LetopiaPlatform.Core.Common;
+
+/// <summary>
+/// Extends <see cref="BaseEntity"/> with automatic audit timestamps.
+/// <para>
+/// <c> CreatedAt</c> is set on insert; <c>UpdatedAt</c> is set on every update.
+/// Both are populated automatically by the <c>SaveChangesAsync</c> override in the <c>ApplicationDbContext</c>.
+/// </para>
+/// </summary>
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/LetopiaPlatform.Core/Common/BaseEntity.cs
+++ b/src/LetopiaPlatform.Core/Common/BaseEntity.cs
@@ -1,0 +1,9 @@
+namespace LetopiaPlatform.Core.Common;
+
+/// <summary>
+/// Base class for all domain entities providing a consistent identifier.
+/// </summary>
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; }
+}

--- a/src/LetopiaPlatform.Core/Entities/Comment.cs
+++ b/src/LetopiaPlatform.Core/Entities/Comment.cs
@@ -1,16 +1,13 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using LetopiaPlatform.Core.Common;
 using LetopiaPlatform.Core.Entities.Identity;
 
 namespace LetopiaPlatform.Core.Entities;
 
 [Table("comments")]
-public class Comment
+public class Comment : AuditableEntity
 {
-    [Key]
-    [Column("id")]
-    public Guid Id { get; set; }
-
     [Required]
     [Column("post_id")]
     public Guid PostId { get; set; }
@@ -31,10 +28,4 @@ public class Comment
 
     [Column("upvotes")]
     public int Upvotes { get; set; }
-
-    [Column("created_at")]
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-
-    [Column("updated_at")]
-    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/src/LetopiaPlatform.Core/Entities/Community.cs
+++ b/src/LetopiaPlatform.Core/Entities/Community.cs
@@ -1,16 +1,13 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using LetopiaPlatform.Core.Common;
 using LetopiaPlatform.Core.Entities.Identity;
 
 namespace LetopiaPlatform.Core.Entities;
 
 [Table("communities")]
-public class Community
+public class Community : AuditableEntity
 {
-    [Key]
-    [Column("id")]
-    public Guid Id { get; set; }
-
     [Required]
     [MaxLength(100)]
     [Column("name")]
@@ -46,12 +43,6 @@ public class Community
 
     [Column("post_count")]
     public int PostCount { get; set; }
-
-    [Column("created_at")]
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-
-    [Column("updated_at")]
-    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
     [MaxLength(500)]
     [Column("cover_image_url")]

--- a/src/LetopiaPlatform.Core/Entities/UserCommunity.cs
+++ b/src/LetopiaPlatform.Core/Entities/UserCommunity.cs
@@ -1,16 +1,13 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using LetopiaPlatform.Core.Common;
 using LetopiaPlatform.Core.Entities.Identity;
 
 namespace LetopiaPlatform.Core.Entities;
 
 [Table("user_communities")]
-public class UserCommunity
+public class UserCommunity : BaseEntity
 {
-    [Key]
-    [Column("id")]
-    public Guid Id { get; set; }
-
     [Required]
     [Column("user_id")]
     public Guid UserId { get; set; }


### PR DESCRIPTION
- Create BaseEntity with shared Guid Id
- Create AuditableEntity extending BaseEntity with CreatedAt/UpdatedAt
- Override SaveChangesAsync to auto-populate timestamps
- Refactor Community, Post, Comment to extend AuditableEntity
- Refactor UserCommunity to extend BaseEntity
- No schema changes — backward compatible

Closes #52