### PR TITLE
featu(core): add soft-delete global query filter

### DIFF
--- a/src/LetopiaPlatform.Core/Entities/Post.cs
+++ b/src/LetopiaPlatform.Core/Entities/Post.cs
@@ -1,17 +1,15 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using LetopiaPlatform.Core.Common;
 using LetopiaPlatform.Core.Entities.Identity;
 using LetopiaPlatform.Core.Enums;
+using LetopiaPlatform.Core.Interfaces;
 
 namespace LetopiaPlatform.Core.Entities;
 
 [Table("posts")]
-public class Post
+public class Post : AuditableEntity, ISoftDeletable
 {
-    [Key]
-    [Column("id")]
-    public Guid Id { get; set; }
-
     [Required]
     [Column("community_id")]
     public Guid CommunityId { get; set; }
@@ -44,12 +42,6 @@ public class Post
 
     [Column("comment_count")]
     public int CommentCount { get; set; }
-
-    [Column("created_at")]
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-
-    [Column("updated_at")]
-    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
     [Column("is_pinned")]
     public bool IsPinned { get; set; }

--- a/src/LetopiaPlatform.Core/Interfaces/ISoftDeletable.cs
+++ b/src/LetopiaPlatform.Core/Interfaces/ISoftDeletable.cs
@@ -1,0 +1,18 @@
+namespace LetopiaPlatform.Core.Interfaces;
+
+/// <summary>
+/// Marker interface for entities supporting soft deletion.
+/// <para>
+/// Entities implementing this interface will have a global query filter applied automatically by <c>ApplicationDbContext</c>, execluding records where <c>IsDeleted == true</c> from all standard queries.
+/// </para>
+/// <para>
+/// Use <c>.IgnoreQueryFilters()</c> to include soft-deleted records (e.g., moderation dashboards, admin views).
+/// </para>
+/// </summary>
+public interface ISoftDeletable
+{
+    /// <summary>
+    /// Indicates whether the entity has been soft-deleted.
+    /// </summary>
+    bool IsDeleted { get; set; }
+}


### PR DESCRIPTION
- Create ISoftDeletable interface
- Post now implements ISoftDeletable
- Apply global query filter via reflection in ApplicationDbContext
- Soft-deleted records execulded from all standard queries
- Use .IgnoreQueryFilters() for admin/moderation views

Closes: #56