### PR TITLE
feat(api): add health check endpoint with PostgreSQL probe

### DIFF
--- a/src/LetopiaPlatform.API/Program.cs
+++ b/src/LetopiaPlatform.API/Program.cs
@@ -61,6 +61,7 @@ public class Program
             app.UseAuthentication();
             app.UseAuthorization();
 
+            app.MapHealthChecks("/health");
             app.MapControllers();
             app.Run();
         }

--- a/src/LetopiaPlatform.Infrastructure/DependencyInjection.cs
+++ b/src/LetopiaPlatform.Infrastructure/DependencyInjection.cs
@@ -131,4 +131,20 @@ public static class DependencyInjection
 
         return services;
     }
+
+    private static IServiceCollection AddHealthCheckServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("DefaultConnection string missing.");
+        
+        services.AddHealthChecks()
+            .AddNpgSql(
+                connectionString,
+                name: "postgresql",
+                tags: ["db", "ready"]);
+        
+        return services;
+    }
 }

--- a/src/LetopiaPlatform.Infrastructure/LetopiaPlatform.Infrastructure.csproj
+++ b/src/LetopiaPlatform.Infrastructure/LetopiaPlatform.Infrastructure.csproj
@@ -30,5 +30,8 @@
 	  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.22" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+
+	  <!-- Health Checks -->
+	  <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add AspNetCore.HealthChecks.NpgSql package
- Register health check with PostgreSQL connectivity test
- Map GET /health (public, no auth)
- Returns 200/Healthy or 503/Unhealthy
- Compatible with Azure App Service health probes

Closes #55