### PR TITLE
feat: add community endpoints for creation, listing, and management (#109)

### DIFF
--- a/src/LetopiaPlatform.API/AppMetaData/Router.cs
+++ b/src/LetopiaPlatform.API/AppMetaData/Router.cs
@@ -23,4 +23,17 @@ public static class Router
         public const string UploadFile = $"{Prefix}/me/files";
         public const string DeleteFile = $"{Prefix}/me/files";
     }
+
+    public static class Communities
+    {
+        public const string Prefix = $"{Rule}/communities";
+        public const string Create = Prefix;
+        public const string List = Prefix;
+        public const string GetBySlug = $"{Prefix}/{{slug}}";
+        public const string Update = $"{Prefix}/{{id}}";
+        public const string Join = $"{Prefix}/{{id}}/join";
+        public const string Leave = $"{Prefix}/{{id}}/leave";
+        public const string Members = $"{Prefix}/{{id}}/members";
+        public const string ChangeRole = $"{Prefix}/{{id}}/members/{{userId}}/role";
+    }
 }

--- a/src/LetopiaPlatform.API/Controllers/CommunitiesController.cs
+++ b/src/LetopiaPlatform.API/Controllers/CommunitiesController.cs
@@ -1,0 +1,174 @@
+using LetopiaPlatform.API.AppMetaData;
+using LetopiaPlatform.API.Common;
+using LetopiaPlatform.API.Extensions;
+using LetopiaPlatform.Core.Common;
+using LetopiaPlatform.Core.DTOs.Community;
+using LetopiaPlatform.Core.Interfaces;
+using LetopiaPlatform.Core.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LetopiaPlatform.API.Controllers;
+
+[Authorize]
+public class CommunitiesController : BaseController
+{
+    private readonly ICommunityService _communityService;
+
+    public CommunitiesController(ICommunityService communityService)
+    {
+        _communityService = communityService;
+    }
+
+    /// <summary>
+    /// Create a new community. Caller becomes the Owner.
+    /// Two default channels (Announcements + General) are auto-created.
+    /// </summary>
+    [HttpPost(Router.Communities.Create)]
+    [ProducesResponseType(typeof(ApiResponse<CommunityDetailDto>), StatusCodes.Status201Created)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateCommunityRequest request,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "create_community");
+        HttpContext.AddBusinessContext("community_name", request.Name);
+
+        var result = await _communityService.CreateAsync(request, GetUserId(), ct);
+
+        HttpContext.AddBusinessContext("community_id", result.Id);
+        HttpContext.AddBusinessContext("community_slug", result.Slug);
+
+        return StatusCode(StatusCodes.Status201Created,
+            ApiResponse<CommunityDetailDto>.SuccessResponse(result, "Community created successfully", 201));
+    }
+
+    /// <summary>
+    /// List communities with optional filtering, searching, and sorting.
+    /// </summary>
+    [HttpGet(Router.Communities.List)]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<PaginatedResult<CommunitySummaryDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> List(
+        [FromQuery] PaginatedQuery query,
+        [FromQuery] string? category,
+        [FromQuery] string? search,
+        [FromQuery] string? sortBy,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "list_communities");
+
+        var result = await _communityService.ListAsync(query, category, search, sortBy, ct);
+
+        return Ok(ApiResponse<PaginatedResult<CommunitySummaryDto>>
+            .SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Get full community details by slug, including channels and membership context.
+    /// </summary>
+    [HttpGet(Router.Communities.GetBySlug)]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<CommunityDetailDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetBySlug(
+        string slug,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "get_community");
+        HttpContext.AddBusinessContext("community_slug", slug);
+
+        Guid? currentUserId = User.Identity?.IsAuthenticated == true ? GetUserId() : null;
+
+        var result = await _communityService.GetBySlugAsync(slug, currentUserId, ct);
+
+        return Ok(ApiResponse<CommunityDetailDto>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Update community settings. Only Owner or Moderator can update.
+    /// </summary>
+    [HttpPut(Router.Communities.Update)]
+    [ProducesResponseType(typeof(ApiResponse<CommunityDetailDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateCommunityRequest request,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "update_community");
+        HttpContext.AddBusinessContext("community_id", id);
+
+        var result = await _communityService.UpdateAsync(id, request, GetUserId(), ct);
+
+        return Ok(ApiResponse<CommunityDetailDto>.SuccessResponse(result, "Community updated successfully"));
+    }
+
+    /// <summary>
+    /// Join a community as a Member.
+    /// </summary>
+    [HttpPost(Router.Communities.Join)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> Join(Guid id, CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "join_community");
+        HttpContext.AddBusinessContext("community_id", id);
+
+        await _communityService.JoinAsync(id, GetUserId(), ct);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Leave a community. Owner cannot leave (must transfer ownership first).
+    /// </summary>
+    [HttpDelete(Router.Communities.Leave)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> Leave(Guid id, CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "leave_community");
+        HttpContext.AddBusinessContext("community_id", id);
+
+        await _communityService.LeaveAsync(id, GetUserId(), ct);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// List community members with pagination.
+    /// </summary>
+    [HttpGet(Router.Communities.Members)]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<PaginatedResult<MemberDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetMembers(
+        Guid id,
+        [FromQuery] PaginatedQuery query,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "get_members");
+        HttpContext.AddBusinessContext("community_id", id);
+
+        var result = await _communityService.GetMembersAsync(id, query, ct);
+
+        return Ok(ApiResponse<PaginatedResult<MemberDto>>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Change a member's role. Only the Owner can do this.
+    /// Transferring to Owner is atomic: new owner gets Owner, old owner becomes Moderator.
+    /// </summary>
+    [HttpPut(Router.Communities.ChangeRole)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> ChangeRole(
+        Guid id,
+        Guid userId,
+        [FromBody] ChangeRoleRequest request,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "change_role");
+        HttpContext.AddBusinessContext("community_id", id);
+        HttpContext.AddBusinessContext("target_user_id", userId);
+        HttpContext.AddBusinessContext("new_role", request.Role);
+
+        await _communityService.ChangeRoleAsync(id, userId, request, GetUserId(), ct);
+
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `CommunitiesController` with all 8 community endpoints, completing **Epic A (#100)**.

## Changes

### Added
- `CommunitiesController` — 8 thin endpoints delegating to `ICommunityService`
- Community routes in `Router.cs`

## Endpoint Design

- **Thin controller** — zero business logic, all in `ICommunityService`
- **Exception-based errors** — service throws `NotFoundException`/`ConflictException`/`ForbiddenException`, caught by `ExceptionMiddleware`
- **`ApiResponse<T>` envelope** on all success responses for consistency
- **`CancellationToken`** on all endpoints
- **Wide event logging** (`HttpContext.AddBusinessContext`) on all endpoints
- **`[AllowAnonymous]`** on public endpoints (List, GetBySlug, GetMembers)
- **`GetBySlug`** optionally extracts user ID for authenticated users to compute `IsMember`/`UserRole`
- **`[ProducesResponseType]`** attributes for Swagger documentation

## Endpoints

| Method | Route | Auth | Status Codes |
|--------|-------|------|-------------|
| `POST` | `/api/v1/communities` | Required | 201, 400 |
| `GET` | `/api/v1/communities` | Public | 200 |
| `GET` | `/api/v1/communities/{slug}` | Public | 200, 404 |
| `PUT` | `/api/v1/communities/{id}` | Owner/Mod | 200, 403, 404 |
| `POST` | `/api/v1/communities/{id}/join` | Required | 204, 403, 404, 409 |
| `DELETE` | `/api/v1/communities/{id}/leave` | Required | 204, 400, 404 |
| `GET` | `/api/v1/communities/{id}/members` | Public | 200, 404 |
| `PUT` | `/api/v1/communities/{id}/members/{userId}/role` | Owner | 204, 400, 403, 404 |

## HTTP Status Codes

- `201 Created` — community created
- `200 OK` — read/update operations
- `204 No Content` — join, leave, role change (no response body needed)
- `400/403/404/409` — domain errors via exception middleware

---

Closes #109

**This PR completes Epic A: Community Core & Membership (#100)**