### PR TITLE
feat(search): add global search across communities, projects, members

### DIFF
--- a/src/LetopiaPlatform.API/AppMetaData/Router.cs
+++ b/src/LetopiaPlatform.API/AppMetaData/Router.cs
@@ -142,6 +142,12 @@ public static class Router
         public const string Delete = $"{Prefix}/Delete/{{communityTaskid:guid}}";
         public const string Toggle = $"{Prefix}/Toggle/{{taskid:guid}}";
     }
+
+    public static class Search
+    {
+        public const string Prefix = $"{Rule}/search";
+        public const string Query = Prefix;
+    }
 }
 
 

--- a/src/LetopiaPlatform.API/Controllers/SearchController.cs
+++ b/src/LetopiaPlatform.API/Controllers/SearchController.cs
@@ -1,0 +1,56 @@
+using LetopiaPlatform.API.AppMetaData;
+using LetopiaPlatform.API.Common;
+using LetopiaPlatform.API.Extensions;
+using LetopiaPlatform.Core.DTOs.Search;
+using LetopiaPlatform.Core.Exceptions;
+using LetopiaPlatform.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LetopiaPlatform.API.Controllers;
+
+[ApiController]
+public class SearchController : BaseController
+{
+    private readonly ISearchService _searchService;
+
+    public SearchController(ISearchService searchService)
+    {
+        _searchService = searchService;
+    }
+
+    [HttpGet(Router.Search.Query)]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<GlobalSearchResultDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Search(
+        [FromQuery] string query,
+        [FromQuery] string? type,
+        [FromQuery] int limit = 5,
+        CancellationToken ct = default)
+    {
+        HttpContext.AddBusinessContext("action", "global_search");
+
+        if (string.IsNullOrWhiteSpace(query) || query.Length < 2)
+        {
+            throw new AppException("Search query must be at least 2 characters.", 400);
+        }
+
+        if (limit is < 1 or > 10)
+        {
+            throw new AppException("Limit must be between 1 and 10.", 400);
+        }
+
+        string[] validTypes = ["communities", "projects", "members"];
+        if (type is not null && !validTypes.Contains(type.ToLowerInvariant()))
+        {
+            throw new AppException($"Type must be one of: {string.Join(", ", validTypes)}.", 400);
+        }
+
+        var results = await _searchService.SearchAsync(query, type?.ToLowerInvariant(), limit, ct);
+
+        return Ok(ApiResponse<GlobalSearchResultDto>.SuccessResponse(results));
+
+    }
+}

--- a/src/LetopiaPlatform.Core/DTOs/Search/GlobalSearchResultDto.cs
+++ b/src/LetopiaPlatform.Core/DTOs/Search/GlobalSearchResultDto.cs
@@ -1,0 +1,9 @@
+using LetopiaPlatform.Core.DTOs.Community;
+using LetopiaPlatform.Core.DTOs.User;
+
+namespace LetopiaPlatform.Core.DTOs.Search;
+
+public sealed record GlobalSearchResultDto(
+    List<CommunitySummaryDto> Communities,
+    List<ProjectSearchResultDto> Projects,
+    List<UserSummaryDto> Members);

--- a/src/LetopiaPlatform.Core/DTOs/Search/ProjectSearchResultDto.cs
+++ b/src/LetopiaPlatform.Core/DTOs/Search/ProjectSearchResultDto.cs
@@ -1,0 +1,10 @@
+namespace LetopiaPlatform.Core.DTOs.Search;
+
+public sealed record ProjectSearchResultDto(
+    Guid Id,
+    string Title,
+    string Description,
+    string? CoverImageUrl,
+    string CategoryName,
+    string? DifficultyLevel,
+    string Status);

--- a/src/LetopiaPlatform.Core/DTOs/User/UserSummaryDto.cs
+++ b/src/LetopiaPlatform.Core/DTOs/User/UserSummaryDto.cs
@@ -1,0 +1,7 @@
+namespace LetopiaPlatform.Core.DTOs.User;
+
+public sealed record UserSummaryDto(
+    Guid Id,
+    string FullName,
+    string UserName,
+    string? AvatarUrl);

--- a/src/LetopiaPlatform.Core/Interfaces/ISearchService.cs
+++ b/src/LetopiaPlatform.Core/Interfaces/ISearchService.cs
@@ -1,0 +1,28 @@
+using LetopiaPlatform.Core.DTOs.Search;
+
+namespace LetopiaPlatform.Core.Interfaces;
+
+/// <summary>
+/// Defines a service for performing global searches based on a query and optional filters.
+/// </summary>
+/// <remarks>Implementations of this interface should support asynchronous search operations and allow callers to
+/// specify the maximum number of results and an optional type filter. The service is intended to be used in scenarios
+/// where search functionality is required across multiple domains or entities. Thread safety and cancellation support
+/// depend on the specific implementation.</remarks>
+public interface ISearchService
+{
+    /// <summary>
+    /// Performs an asynchronous global search using the specified query and optional filters.
+    /// </summary>
+    /// <param name="query">The search query to use for finding matching results. Represents the search term as a string value.</param>
+    /// <param name="type">An optional filter specifying the type of results to include. If null, all result types are considered.</param>
+    /// <param name="limit">The maximum number of results to return. Must be greater than zero.</param>
+    /// <param name="ct">A cancellation token that can be used to cancel the search operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a <see
+    /// cref="GlobalSearchResultDto"/> with the search results matching the specified criteria.</returns>
+    Task<GlobalSearchResultDto> SearchAsync(
+        string query,
+        string? type = null,
+        int limit = 5,
+        CancellationToken ct = default);
+}

--- a/src/LetopiaPlatform.Infrastructure/DependencyInjection.cs
+++ b/src/LetopiaPlatform.Infrastructure/DependencyInjection.cs
@@ -151,6 +151,7 @@ public static class DependencyInjection
         services.AddScoped<IReactionRepository, ReactionRepository>();
         services.AddScoped<ITagRepository, TagRepository>();
 
+        services.AddScoped<ISearchService, SearchService>();
         services.AddScoped<IPostAuthorizationService, PostAuthorizationService>();
         services.AddScoped<IPostService, PostService>();
         services.AddScoped<ICommentService, CommentService>();
@@ -165,7 +166,6 @@ public static class DependencyInjection
         services.AddScoped<ICommunityTaskCategoryService, CommunityTaskCategoryService>();
         services.AddScoped<IRoadmapRepository, RoadmapRepository>();
         services.AddScoped<IConversationRepository, ConversationRepository>();
-
         services.AddScoped<ICommunityTaskService, CommunityTaskService>();
 
         return services;

--- a/src/LetopiaPlatform.Infrastructure/Services/SearchService.cs
+++ b/src/LetopiaPlatform.Infrastructure/Services/SearchService.cs
@@ -1,0 +1,108 @@
+using LetopiaPlatform.Core.DTOs.Community;
+using LetopiaPlatform.Core.DTOs.Search;
+using LetopiaPlatform.Core.DTOs.User;
+using LetopiaPlatform.Core.Interfaces;
+using LetopiaPlatform.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LetopiaPlatform.Infrastructure.Services;
+
+public class SearchService : ISearchService
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<SearchService> _logger;
+
+    public SearchService(ApplicationDbContext dbContext, ILogger<SearchService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<GlobalSearchResultDto> SearchAsync(
+        string query,
+        string? type = null,
+        int limit = 5,
+        CancellationToken ct = default)
+    {
+        var pattern = $"%{query.Trim()}%";
+
+        var communities = new List<CommunitySummaryDto>();
+        var projects = new List<ProjectSearchResultDto>();
+        var members = new List<UserSummaryDto>();
+
+        // Search communities
+        if (type is null or "communities")
+        {
+            communities = await _dbContext.Communities
+                .AsNoTracking()
+                .Where(c => c.IsActive)
+                .Where(c =>
+                    EF.Functions.ILike(c.Name, pattern) ||
+                    EF.Functions.ILike(c.Description, pattern))
+                .OrderByDescending(c => c.MemberCount)
+                .Take(limit)
+                .Select(c => new CommunitySummaryDto(
+                    c.Id, c.Name, c.Slug, c.Description,
+                    c.CategoryId, c.Category.ParentCategory != null
+                        ? c.Category.ParentCategory.Name : c.Category.Name,
+                    c.Category.ParentCategory != null
+                        ? c.Category.ParentCategory.IconUrl : c.Category.IconUrl,
+                    c.CoverImageUrl,
+                    c.MemberCount,
+                    c.PostCount,
+                    c.IsPrivate,
+                    c.CreatedAt,
+                    c.Category.Name,
+                    c.Category.Slug,
+                    c.Category.ParentCategoryId ?? c.CategoryId))
+                .ToListAsync(ct);
+        }
+
+        // Search projects
+        if (type is null or "projects")
+        {
+            projects = await _dbContext.Projects
+                .AsNoTracking()
+                .Where(p =>
+                    EF.Functions.ILike(p.Title, pattern) ||
+                    EF.Functions.ILike(p.Description, pattern))
+                .OrderByDescending(p => p.CreatedAt)
+                .Take(limit)
+                .Select(p => new ProjectSearchResultDto(
+                    p.Id,
+                    p.Title,
+                    p.Description,
+                    p.CoverImageUrl,
+                    p.Category.Name,
+                    p.DifficultyLevel.ToString(),
+                    p.Status.ToString()))
+                .ToListAsync(ct);
+        }
+
+        // Search members
+        if (type is null or "members")
+        {
+            members = await _dbContext.Users
+                .AsNoTracking()
+                .Where(u =>
+                    (u.FullName != null && EF.Functions.ILike(u.FullName, pattern)) ||
+                    (u.UserName != null && EF.Functions.ILike(u.UserName, pattern)))
+                .OrderBy(u => u.FullName)
+                .Take(limit)
+                .Select(u => new UserSummaryDto(
+                    u.Id,
+                    u.FullName ?? u.UserName ?? string.Empty,
+                    u.UserName ?? string.Empty,
+                    u.AvatarUrl))
+                .ToListAsync(ct);
+        }
+
+        _logger.LogInformation(
+            "Search completed: query='{Query}', type={Type}, results: {Communities}C/{Projects}P/{Members}M",
+            query, type ?? "all",
+            communities.Count, projects.Count, members.Count);
+
+        return new GlobalSearchResultDto(communities, projects, members);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a global search endpoint that queries across communities, projects, and platform members.

## Endpoint

`GET /api/v1/search?query=Des&type=communities&limit=5`

| Param | Type | Required | Description |
|-------|------|----------|-------------|
| `query` | string | Yes | Search query (min 2 characters) |
| `type` | string | No | `communities`, `projects`, or `members`. Omit for all. |
| `limit` | int | No | Results per type (1-10, default 5) |

## What it searches

| Type | Fields searched | Sorted by |
|------|----------------|-----------|
| Communities | Name, Description | Member count (desc) |
| Projects | Title, Description | Created date (desc) |
| Members | FullName, UserName | Name (asc) |

## Files Added
- `Core/DTOs/User/UserSummaryDto.cs`
- `Core/DTOs/Search/GlobalSearchResultDto.cs`
- `Core/DTOs/Search/ProjectSearchResultDto.cs`
- `Core/Interfaces/ISearchService.cs`
- `Infrastructure/Services/SearchService.cs`
- `API/Controllers/SearchController.cs`
- `docs/search-api-collection.json`

## Files Modified
- `Infrastructure/DependencyInjection.cs` — registered `ISearchService`
- `API/AppMetaData/Router.cs` — added `Search` route group