### PR TITLE
fix: add default values to NOT NULL migration columns on projects table 

### DIFF
--- a/src/LetopiaPlatform.Infrastructure/Migrations/20260426010023_UpdateInProjectTable.cs
+++ b/src/LetopiaPlatform.Infrastructure/Migrations/20260426010023_UpdateInProjectTable.cs
@@ -76,7 +76,8 @@ namespace LetopiaPlatform.Infrastructure.Migrations
                 name: "timeline_events",
                 table: "projects",
                 type: "text[]",
-                nullable: false);
+                nullable: false,
+                defaultValueSql: "ARRAY[]::text[]");
 
             migrationBuilder.CreateTable(
                 name: "project_milestones",

--- a/src/LetopiaPlatform.Infrastructure/Migrations/20260426152658_dropMilstoneDetailsTable.cs
+++ b/src/LetopiaPlatform.Infrastructure/Migrations/20260426152658_dropMilstoneDetailsTable.cs
@@ -21,7 +21,7 @@ namespace LetopiaPlatform.Infrastructure.Migrations
             table: "projects",
             type: "jsonb",
             nullable: false,
-            defaultValue: "[]"); 
+            defaultValueSql: "'[]'::jsonb"); 
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description
Fixes `Npgsql.PostgresException` thrown during `MigrationAsync` at startup.

## Problem
Two recent migrations add NOT NULL to the `projects` table without providing default values. When the table already contains rows, PostgreSQL rejects the `ALTER TABLE ... AND COLUMN ... NOT NULL` because existing rows would have no value for the new column.

## Changes
- `UpdateInProjectTable`: added `defaultValueSql: "ARRAY[]::text[]"` to the `timeline_events` column (`text[]`, NOT NULL)
- `dropMilestomeDetailsTable`: Changed `defaultValue: "[]" (invalid CLR string) to `defaultValueSql: "'[]'::jsonb"` on the `milestones` column `jsonb`, NOT NULL)

## Root Cause
PostgreSQL cannot add a NOT NULL column to a table with existing rows unless a server-side default is provided. Additionally, EF Core's expects a CLR object, not a raw SQL literal — is the correct parameter for PostgreSQL-native expressions.