### PR TITLE
feat: add FluentValidation validators for agent endpoints (# 196)

### DIFF
--- a/src/LetopiaPlatform.API/Validators/SendMessageRequestValidator.cs
+++ b/src/LetopiaPlatform.API/Validators/SendMessageRequestValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using LetopiaPlatform.Core.DTOs.Agent;
+
+namespace LetopiaPlatform.API.Validators;
+
+public class SendMessageRequestValidator : AbstractValidator<SendMessageRequest>
+{
+    public SendMessageRequestValidator()
+    {
+        RuleFor(x => x.Content)
+            .NotEmpty().WithMessage("Message content is required.")
+            .MaximumLength(2000).WithMessage("Message must not exceed 2000 characters.");
+    }
+}

--- a/src/LetopiaPlatform.API/Validators/StartConversationRequestValidator.cs
+++ b/src/LetopiaPlatform.API/Validators/StartConversationRequestValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using LetopiaPlatform.Core.DTOs.Agent;
+
+namespace LetopiaPlatform.API.Validators;
+
+public class StartConversationRequestValidator : AbstractValidator<StartConversationRequest>
+{
+    public StartConversationRequestValidator()
+    {
+        RuleFor(x => x.InitialMessage)
+            .NotEmpty().WithMessage("Initial message is required.")
+            .MaximumLength(1000).WithMessage("Initial message must not exceed 1000 characters.");
+    }
+}

--- a/src/LetopiaPlatform.API/Validators/UpdatePhaseStatusRequestValidator.cs
+++ b/src/LetopiaPlatform.API/Validators/UpdatePhaseStatusRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using LetopiaPlatform.Core.DTOs.Agent;
+
+namespace LetopiaPlatform.API.Validators;
+
+public class UpdatePhaseStatusRequestValidator : AbstractValidator<UpdatePhaseStatusRequest>
+{
+    public UpdatePhaseStatusRequestValidator()
+    {
+        RuleFor(x => x.Status)
+            .IsInEnum().WithMessage("Invalid phase status.");
+    }
+}

--- a/tests/LetopiaPlatform.UnitTests/LetopiaPlatform.UnitTests.csproj
+++ b/tests/LetopiaPlatform.UnitTests/LetopiaPlatform.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -23,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\LetopiaPlatform.Core\LetopiaPlatform.Core.csproj" />
     <ProjectReference Include="..\..\src\LetopiaPlatform.Agent\LetopiaPlatform.Agent.csproj" />
+    <ProjectReference Include="..\..\src\LetopiaPlatform.API\LetopiaPlatform.API.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/LetopiaPlatform.UnitTests/Validators/AgentRequestValidatorTests.cs
+++ b/tests/LetopiaPlatform.UnitTests/Validators/AgentRequestValidatorTests.cs
@@ -1,0 +1,115 @@
+using FluentValidation.TestHelper;
+using LetopiaPlatform.API.Validators;
+using LetopiaPlatform.Core.DTOs.Agent;
+using LetopiaPlatform.Core.Enums;
+
+namespace LetopiaPlatform.UnitTests.Validators;
+
+public class StartConversationRequestValidatorTests
+{
+    private readonly StartConversationRequestValidator _validator = new();
+
+    [Fact]
+    public void ValidInitialMessagePassesValidation()
+    {
+        var request = new StartConversationRequest("I want to learn C#");
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyInitialMessageFailsValidation(string? message)
+    {
+        var request = new StartConversationRequest(message!);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.InitialMessage)
+            .WithErrorMessage("Initial message is required.");
+    }
+
+    [Fact]
+    public void OversizedInitialMessageFailsValidation()
+    {
+        var request = new StartConversationRequest(new string('a', 1001));
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.InitialMessage)
+            .WithErrorMessage("Initial message must not exceed 1000 characters.");
+    }
+
+    [Fact]
+    public void MaxLengthInitialMessagePassesValidation()
+    {
+        var request = new StartConversationRequest(new string('a', 1000));
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}
+
+public class SendMessageRequestValidatorTests
+{
+    private readonly SendMessageRequestValidator _validator = new();
+
+    [Fact]
+    public void ValidContentPassesValidation()
+    {
+        var request = new SendMessageRequest("Tell me more about phase 2");
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyContentFailsValidation(string? content)
+    {
+        var request = new SendMessageRequest(content!);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Content)
+            .WithErrorMessage("Message content is required.");
+    }
+
+    [Fact]
+    public void OversizedContentFailsValidation()
+    {
+        var request = new SendMessageRequest(new string('a', 2001));
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Content)
+            .WithErrorMessage("Message must not exceed 2000 characters.");
+    }
+
+    [Fact]
+    public void MaxLengthContentPassesValidation()
+    {
+        var request = new SendMessageRequest(new string('a', 2000));
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}
+
+public class UpdatePhaseStatusRequestValidatorTests
+{
+    private readonly UpdatePhaseStatusRequestValidator _validator = new();
+
+    [Theory]
+    [InlineData(PhaseStatus.NotStarted)]
+    [InlineData(PhaseStatus.InProgress)]
+    [InlineData(PhaseStatus.Completed)]
+    public void ValidPhaseStatusPassesValidation(PhaseStatus status)
+    {
+        var request = new UpdatePhaseStatusRequest(status);
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void InvalidEnumValueFailsValidation()
+    {
+        var request = new UpdatePhaseStatusRequest((PhaseStatus)999);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Status)
+            .WithErrorMessage("Invalid phase status.");
+    }
+}


### PR DESCRIPTION
---

## Description

Adds FluentValidation validators for agent request DTOs to enforce input validation rules at the API layer. Includes comprehensive unit tests covering valid inputs, empty/null/whitespace cases, boundary lengths, and invalid enum values.

---

## Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation
* [x] 🧪 Tests
* [ ] ⚙️ Configuration / CI

---

## Changes Made

* Added `StartConversationRequestValidator`

  * Validates `InitialMessage` is not empty and ≤ 1000 characters
* Added `SendMessageRequestValidator`

  * Validates `Content` is not empty and ≤ 2000 characters
* Added `UpdatePhaseStatusRequestValidator`

  * Validates `Status` is a valid `PhaseStatus` enum value
* Added unit tests (`AgentRequestValidatorTests`)

  * Covers valid inputs, empty/null/whitespace, boundary limits, and invalid enum cases
* Follows existing validation conventions (aligned with `LoginDtoValidator`)

---

## Related Issue

Closes #196

---

## How to Test

1. Run:

   ```bash
   dotnet build
   dotnet test
   ```
2. Verify all tests pass (16 tests)
3. Optionally, send invalid requests to endpoints and confirm validation errors are returned automatically

---

## Checklist

* [x] Code builds without errors (`dotnet build`)
* [x] No new warnings introduced
* [x] Self-reviewed the code
* [x] Added/updated tests (if applicable)
* [ ] API changes documented (if applicable)
* [x] No sensitive data (secrets, keys) committed

---

## Screenshots

N/A (no UI changes)
