### PR TITLE
feat: Remove member from community endpoint

### DIFF
--- a/src/LetopiaPlatform.API/AppMetaData/Router.cs
+++ b/src/LetopiaPlatform.API/AppMetaData/Router.cs
@@ -52,6 +52,7 @@ public static class Router
         public const string Leave = $"{Prefix}/{{id}}/leave";
         public const string Members = $"{Prefix}/{{id}}/members";
         public const string ChangeRole = $"{Prefix}/{{id}}/members/{{userId}}/role";
+        public const string RemoveMember = $"{Prefix}/{{id}}/members/{{userId}}";
     }
 
     public static class Categories

--- a/src/LetopiaPlatform.API/Controllers/CommunitiesController.cs
+++ b/src/LetopiaPlatform.API/Controllers/CommunitiesController.cs
@@ -190,6 +190,29 @@ public class CommunitiesController : BaseController
         return NoContent();
     }
 
+    /// <summary>
+    /// Remove a member from a community. Owner or Moderator only.
+    /// Owner cannot be removed. a moderator can only removed by the Owner.
+    /// </summary>
+    [HttpDelete(Router.Communities.RemoveMember)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> RemoveMember(
+        Guid id,
+        Guid userId,
+        CancellationToken ct)
+    {
+        HttpContext.AddBusinessContext("action", "remove_member");
+        HttpContext.AddBusinessContext("community_id", id);
+        HttpContext.AddBusinessContext("target_user_id", userId);
+
+        await _communityService.RemoveMemberAsync(id, userId, GetUserId(User), ct);
+
+        return NoContent();
+    }
+
     private static Guid GetUserId(ClaimsPrincipal claimsPrincipal)
     {
         return Guid.Parse(claimsPrincipal.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);

--- a/src/LetopiaPlatform.Core/Interfaces/ICommunityService.cs
+++ b/src/LetopiaPlatform.Core/Interfaces/ICommunityService.cs
@@ -123,4 +123,19 @@ public interface ICommunityService
     Task<List<JoinedCommunitySummaryDto>> GetJoinedCommunitiesAsync(
         Guid userId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a member from the community. Only Owner or Moderator can do this. Cannot remove Owner.
+    /// Callers cannot remove themselves - use <see cref="LeaveAsync"/> to leave voluntarily.
+    /// </summary>
+    /// <param name="communityId">The ID of the community.</param>
+    /// <param name="targetUserId">The ID of the user to be removed.</param>
+    /// <param name="callerUserId">The ID of the user performing the removal.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RemoveMemberAsync(
+        Guid communityId,
+        Guid targetUserId,
+        Guid callerUserId,
+        CancellationToken ct = default);
 }

--- a/src/LetopiaPlatform.Infrastructure/Services/CommunityService.cs
+++ b/src/LetopiaPlatform.Infrastructure/Services/CommunityService.cs
@@ -325,9 +325,20 @@ public class CommunityService : ICommunityService
         if (targetMembership.Role == CommunityRole.Moderator && callerMembership.Role != CommunityRole.Owner)
             throw new ForbiddenException("Only the owner can remove a moderator.");
 
-        _communityRepository.RemoveMember(targetMembership);
-        await _unitOfWork.SaveChangesAsync(ct);
-        await _communityRepository.DecrementMemberCountAsync(communityId, ct);
+        await _unitOfWork.beginTransactionAsync();
+        try
+        {
+            _communityRepository.RemoveMember(targetMembership);
+            await _unitOfWork.SaveChangesAsync(ct);
+            await _communityRepository.DecrementMemberCountAsync(communityId, ct);
+            await _unitOfWork.CommitAsync();
+        }
+        catch
+        {
+            await _unitOfWork.RollbackAsync();
+            throw;
+        }
+
 
         _logger.LogInformation(
             "Community Service - User {TargetUserId} removed from community {CommunityId} by {CallerId}",

--- a/src/LetopiaPlatform.Infrastructure/Services/CommunityService.cs
+++ b/src/LetopiaPlatform.Infrastructure/Services/CommunityService.cs
@@ -300,6 +300,40 @@ public class CommunityService : ICommunityService
         return await _communityRepository.GetJoinedCommunitiesAsync(userId, ct);
     }
 
+    public async Task RemoveMemberAsync(
+        Guid communityId,
+        Guid targetUserId,
+        Guid callerUserId,
+        CancellationToken ct = default)
+    {
+        if (callerUserId == targetUserId)
+            throw new AppException("You cannot remove yourself. Use the leave endpoint to leave voluntarily.", 400);
+        
+        var callerMembership = await _communityRepository.GetMembershipAsync(communityId, callerUserId, ct)
+            ?? throw new ForbiddenException("You are not a member of this community.");
+        
+        if (callerMembership.Role is not (CommunityRole.Owner or CommunityRole.Moderator))
+            throw new ForbiddenException("Only the owner or a moderator can remove members.");
+        
+        var targetMembership = await _communityRepository.GetMembershipAsync(communityId, targetUserId, ct)
+            ?? throw new NotFoundException("Member not found in this community.");
+        
+        if (targetMembership.Role == CommunityRole.Owner)
+            throw new AppException("The owner cannot be removed. Transfer ownership first.", 400);
+        
+        // Only the owner can remove moderators, but both owner and moderators can remove members
+        if (targetMembership.Role == CommunityRole.Moderator && callerMembership.Role != CommunityRole.Owner)
+            throw new ForbiddenException("Only the owner can remove a moderator.");
+
+        _communityRepository.RemoveMember(targetMembership);
+        await _unitOfWork.SaveChangesAsync(ct);
+        await _communityRepository.DecrementMemberCountAsync(communityId, ct);
+
+        _logger.LogInformation(
+            "Community Service - User {TargetUserId} removed from community {CommunityId} by {CallerId}",
+            targetUserId, communityId, callerUserId);
+    }
+
     // Private helpers
     private static List<Channel> CreateDefaultChannels(Guid communityId)
     {


### PR DESCRIPTION
## Description

Add an endpoint to remove a member from a community, restricted to owners and moderators. The owner cannot be removed, and moderators can only be removed by the owner.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] ⚙️ Configuration / CI

## Changes Made

- Introduced a new endpoint for removing a member from a community.
- Implemented business logic to enforce role-based access control for member removal.

## Related Issue

<!-- Link to issue: Closes #123 -->

## How to Test

1. Call the new endpoint with valid community and user IDs.
2. Verify that only owners and moderators can remove members.

## Checklist

- [ ] Code builds without errors (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Self-reviewed the code
- [ ] Added/updated tests (if applicable)
- [ ] API changes documented (if applicable)
- [ ] No sensitive data (secrets, keys) committed

## Screenshots

<!-- If UI or API response changes, add screenshots -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community owners and moderators can remove members from their communities via a new API endpoint. Removals update member counts, enforce role rules (owners cannot be removed; moderators can remove non-owner members; only owners can remove moderators), and prevent self-removal. The operation returns a success when completed and provides appropriate error responses for invalid or unauthorized requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LetopiaPlatform/LetopiaPlatform/pull/251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->