### PR TITLE
fix: remove duplicate bio property from MemberDto

### DIFF
--- a/src/LetopiaPlatform.Core/DTOs/Community/MemberDto.cs
+++ b/src/LetopiaPlatform.Core/DTOs/Community/MemberDto.cs
@@ -7,7 +7,6 @@ namespace LetopiaPlatform.Core.DTOs.Community;
 public sealed record MemberDto(
     Guid UserId,
     string FullName,
-    string? Bio,
     string? AvatarUrl,
     string? Bio,
     string Role,


### PR DESCRIPTION


Removed the duplicate Bio property from MemberDto to streamline the data structure.



## Type of Change



- [x] 🐛 Bug fix

- [ ] ✨ New feature

- [ ] ♻️ Refactor

- [ ] 📝 Documentation

- [ ] 🧪 Tests

- [ ] ⚙️ Configuration / CI



## Changes Made



- Removed duplicate Bio property from MemberDto.



## Related Issue



<!-- Link to issue: Closes #123 -->



## How to Test



1. Verify that the MemberDto no longer contains duplicate Bio properties.

2. Ensure that existing functionality remains unaffected.



## Checklist



- [ ] Code builds without errors (`dotnet build`)

- [ ] No new warnings introduced

- [ ] Self-reviewed the code

- [ ] Added/updated tests (if applicable)

- [ ] API changes documented (if applicable)

- [ ] No sensitive data (secrets, keys) committed



## Screenshots



<!-- If UI or API response changes, add screenshots -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal data structure reorganization for improved code consistency. No user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LetopiaPlatform/LetopiaPlatform/pull/254)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->