### PR TITLE
Increase AvatarUrl record length to text type for better storage

### DIFF
--- a/src/LetopiaPlatform.Infrastructure/Data/Configurations/UserConfiguration.cs
+++ b/src/LetopiaPlatform.Infrastructure/Data/Configurations/UserConfiguration.cs
@@ -16,7 +16,7 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.Property(u => u.AvatarUrl)
             .HasColumnName("AvatarUrl")
-            .HasMaxLength(500);
+            .HasColumnType("text");
 
         builder.Property(u => u.Bio)
             .HasColumnName("Bio")

--- a/src/LetopiaPlatform.Infrastructure/Migrations/20260421091732_update user profiel and pendding email.Designer.cs
+++ b/src/LetopiaPlatform.Infrastructure/Migrations/20260421091732_update user profiel and pendding email.Designer.cs
@@ -653,8 +653,7 @@ namespace LetopiaPlatform.Infrastructure.Migrations
                         .HasColumnType("integer");
 
                     b.Property<string>("AvatarUrl")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
+                        .HasColumnType("text")
                         .HasColumnName("AvatarUrl");
 
                     b.Property<string>("Bio")

--- a/src/LetopiaPlatform.Infrastructure/Migrations/20260421091732_update user profiel and pendding email.cs
+++ b/src/LetopiaPlatform.Infrastructure/Migrations/20260421091732_update user profiel and pendding email.cs
@@ -44,16 +44,6 @@ namespace LetopiaPlatform.Infrastructure.Migrations
                 oldType: "text",
                 oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AvatarUrl",
-                table: "AspNetUsers",
-                type: "character varying(500)",
-                maxLength: 500,
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "text",
-                oldNullable: true);
-
             migrationBuilder.AddColumn<string>(
                 name: "Location",
                 table: "AspNetUsers",
@@ -169,17 +159,6 @@ namespace LetopiaPlatform.Infrastructure.Migrations
                 oldMaxLength: 1000,
                 oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AvatarUrl",
-                table: "AspNetUsers",
-                type: "text",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "character varying(500)",
-                oldMaxLength: 500,
-                oldNullable: true);
-
-           
         }
     }
 }

--- a/src/LetopiaPlatform.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/LetopiaPlatform.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -651,8 +651,7 @@ namespace LetopiaPlatform.Infrastructure.Migrations
                         .HasColumnType("integer");
 
                     b.Property<string>("AvatarUrl")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
+                        .HasColumnType("text")
                         .HasColumnName("AvatarUrl");
 
                     b.Property<string>("Bio")


### PR DESCRIPTION
## Description

Increases the length of the AvatarUrl field to accommodate larger URLs for better storage.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- Changed AvatarUrl column type from character varying(500) to text.
- Updated related migration and model configurations.

## Related Issue

<!-- Link to issue: Closes #123 -->

## How to Test

1. Verify that the AvatarUrl field can store longer URLs.
2. Check database schema to confirm the column type change.

## Checklist

- [ ] Code builds without errors (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Self-reviewed the code
- [ ] Added/updated tests (if applicable)
- [ ] API changes documented (if applicable)
- [ ] No sensitive data (secrets, keys) committed

## Screenshots

<!-- If UI or API response changes, add screenshots -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Removed character length restriction on user avatar URLs, allowing longer URLs to be stored in user profiles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LetopiaPlatform/LetopiaPlatform/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->